### PR TITLE
added integration test and ingest code for test scenarios

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,3 +42,6 @@ urllib3==1.26.9
 whitenoise==6.0.0
 xlrd==2.0.1
 xlwt==1.3.0
+parameterized
+selenium
+webdriver-manager

--- a/web/fixtures/test_ingest.py
+++ b/web/fixtures/test_ingest.py
@@ -1,0 +1,88 @@
+import csv
+import html
+import os
+from pathlib import Path
+
+from django.utils.html import strip_tags
+
+from topic.models import Topic
+from document.models import Document
+
+from core.models import Task
+
+from user.models import User
+
+ROOT_PATH = "fixtures/data/test"
+Path(ROOT_PATH).mkdir(exist_ok=True, parents=True)
+import pandas as pd
+
+df = pd.read_csv(
+    "https://docs.google.com/spreadsheets/d/1siwC0S1vgs_BB9lQC6z7J1smTDFA3P0oJMfcSy7DYME/export?gid=0&format=csv",
+)
+
+questions = df[["scenario"]].apply(lambda row: pd.Series([row.name, row.scenario, row.scenario]), axis=1)
+# question.to_csv(ROOT_PATH + "/question.csv", index=False, quoting=csv.QUOTE_NONNUMERIC)
+passages = (
+    df.input.apply(lambda x: x.split())
+        .explode().drop_duplicates().apply(lambda x: pd.Series([x, x, x, x], index="uuid title url content".split()))
+)
+# passages.to_csv(ROOT_PATH + "/passages.csv", index=False, quoting=csv.QUOTE_NONNUMERIC)
+pool = (
+    df.input.apply(lambda x: x.split())
+        .explode()
+        .reset_index()
+        .rename(columns=dict(index="topic"))
+        .apply(lambda x: pd.Series([x.topic, x.input]), axis=1)
+)
+# pool.to_csv(ROOT_PATH + "/pool.csv", index=False, quoting=csv.QUOTE_NONNUMERIC)
+Topic.objects.all().delete()
+Document.objects.all().delete()
+Task.objects.all().delete()
+User.objects.filter(username="test_user").delete()
+user = User.objects.create_user(username="test_user", password="test_user@example.com", email="test_user@example.com")
+
+
+print("1- Ingest topic")
+for i, t in questions.iterrows():
+    try:
+        Topic.objects.create(uuid=t[0], title=t[1], description=t[2])
+    except Exception as e:
+        print(f"{t[0]} ==> {e}")
+
+print("2- Ingest Document")
+for i, t in passages.iterrows():
+
+    try:
+        Document.objects.create(
+            uuid=t[0],
+            title=strip_tags(t[1]),
+            url=strip_tags(t[2]),
+            content=html.escape(strip_tags(t[3])) + "\n\n",
+        )
+    except Exception as e:
+        print(e)
+
+print("3- Map document to topics")
+for line in pool.itertuples():
+    _, topic_id, doc_id = line
+    try:
+        document = Document.objects.get(uuid=doc_id)
+        topic = Topic.objects.get(uuid=topic_id)
+        document.topics.add(topic)
+        document.save()
+    except Exception as e:
+        print(e)
+
+print("4- Check if a topic has just one document!")
+for topic in Topic.objects.all():
+    document_list = Document.objects.filter(topics__uuid=topic.uuid)
+    topic.num_related_document = len(document_list)
+    topic.save()
+
+for topic in Topic.objects.all():
+    Task.objects.create(
+        user_id=user.id,
+        topic_id=topic.id
+    )
+
+

--- a/web/fixtures/test_ingest.py
+++ b/web/fixtures/test_ingest.py
@@ -1,15 +1,10 @@
-import csv
 import html
-import os
 from pathlib import Path
 
-from django.utils.html import strip_tags
-
-from topic.models import Topic
-from document.models import Document
-
 from core.models import Task
-
+from django.utils.html import strip_tags
+from document.models import Document
+from topic.models import Topic
 from user.models import User
 
 ROOT_PATH = "fixtures/data/test"
@@ -20,27 +15,23 @@ df = pd.read_csv(
     "https://docs.google.com/spreadsheets/d/1siwC0S1vgs_BB9lQC6z7J1smTDFA3P0oJMfcSy7DYME/export?gid=0&format=csv",
 )
 
-questions = df[["scenario"]].apply(lambda row: pd.Series([row.name, row.scenario, row.scenario]), axis=1)
-# question.to_csv(ROOT_PATH + "/question.csv", index=False, quoting=csv.QUOTE_NONNUMERIC)
+questions = df[["scenario"]].apply(lambda row: pd.Series([row.name, row.scenario, row.scenario]), axis=1).sample(frac=1)
 passages = (
     df.input.apply(lambda x: x.split())
         .explode().drop_duplicates().apply(lambda x: pd.Series([x, x, x, x], index="uuid title url content".split()))
-)
-# passages.to_csv(ROOT_PATH + "/passages.csv", index=False, quoting=csv.QUOTE_NONNUMERIC)
+).sample(frac=1)
 pool = (
     df.input.apply(lambda x: x.split())
         .explode()
         .reset_index()
         .rename(columns=dict(index="topic"))
         .apply(lambda x: pd.Series([x.topic, x.input]), axis=1)
-)
-# pool.to_csv(ROOT_PATH + "/pool.csv", index=False, quoting=csv.QUOTE_NONNUMERIC)
+).sample(frac=1)
 Topic.objects.all().delete()
 Document.objects.all().delete()
 Task.objects.all().delete()
 User.objects.filter(username="test_user").delete()
 user = User.objects.create_user(username="test_user", password="test_user@example.com", email="test_user@example.com")
-
 
 print("1- Ingest topic")
 for i, t in questions.iterrows():
@@ -51,7 +42,6 @@ for i, t in questions.iterrows():
 
 print("2- Ingest Document")
 for i, t in passages.iterrows():
-
     try:
         Document.objects.create(
             uuid=t[0],
@@ -84,5 +74,3 @@ for topic in Topic.objects.all():
         user_id=user.id,
         topic_id=topic.id
     )
-
-

--- a/web/integration_test.py
+++ b/web/integration_test.py
@@ -1,0 +1,96 @@
+import re
+
+import pandas as pd
+from django.test.client import Client
+from django.test import TestCase
+from django.test import LiveServerTestCase
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium import webdriver
+from selenium.webdriver.support.select import Select
+from selenium.webdriver.support.wait import WebDriverWait
+from webdriver_manager.chrome import ChromeDriverManager
+from parameterized import parameterized, parameterized_class
+from selenium.webdriver.support import expected_conditions as EC
+from topic.models import Topic
+from document.models import Document
+
+from core.models import Task
+
+from user.models import User
+from core.models import Task
+from topic.models import Topic
+
+SCENARIOS_PATH = "https://docs.google.com/spreadsheets/d/1siwC0S1vgs_BB9lQC6z7J1smTDFA3P0oJMfcSy7DYME/export?gid=0&format=csv"
+
+class ATestCase(LiveServerTestCase):
+    # @parameterized.expand([(i,) for i in pd.read_csv(SCENARIOS_PATH).scenario.tolist()])
+
+    # @parameterized.expand([(i,) for i in range(1,2)])
+    # fixtures = ["test_ingest"]
+
+
+    def setUp(self) -> None:
+
+        with open('./fixtures/test_ingest.py') as f:
+          exec(f.read())
+        self.df = pd.read_csv(
+            SCENARIOS_PATH,
+        )
+
+    @parameterized.expand([(i,) for i in pd.read_csv(SCENARIOS_PATH).scenario.tolist()])
+    def test_stuff(self, scenario):
+        print("test")
+        selenium = webdriver.Chrome(ChromeDriverManager().install())
+        # Choose your url to visit
+        selenium.get(self.live_server_url)
+        user = selenium.find_element(By.ID, 'id_login')
+        password = selenium.find_element(By.ID, 'id_password')
+        submit = selenium.find_element(By.XPATH, "/html/body/div/form/button")
+
+        user.send_keys('test_user')
+        password.send_keys('test_user@example.com')
+
+        submit.send_keys(Keys.RETURN)
+
+        assert 'Start Judgment' in selenium.page_source
+
+        select = Select(selenium.find_element(By.ID, 'slct'))
+        select.select_by_visible_text(scenario)
+        # select.select_by_index(2)
+        topic_title = select.first_selected_option.text
+        submit = selenium.find_element(By.XPATH, "//*[@id='container']/div/div/button")
+        submit.send_keys(Keys.RETURN)
+
+        print(0)
+        while True:
+            if 'task_status = "complete"' in selenium.page_source:
+                break
+            l_doc = selenium.find_element(By.ID, "left-doc")
+            r_doc = selenium.find_element(By.ID, "right-doc")
+
+            l_title = re.search("^Title: (\w\d+)", l_doc.text).group(1)
+            r_title = re.search("^Title: (\w\d+)", r_doc.text).group(1)
+
+            if l_title[0] < r_title[0]:
+                submit = selenium.find_element(By.XPATH, "/html/body/div[1]/div[1]/div[2]/div/form/button[1]")
+                submit.send_keys(Keys.RETURN)
+            elif l_title[0] > r_title[0]:
+                submit = selenium.find_element(By.XPATH, "/html/body/div[1]/div[1]/div[2]/div/form/button[3]")
+                submit.send_keys(Keys.RETURN)
+            elif l_title[0] == r_title[0]:
+                submit = selenium.find_element(By.XPATH, "/html/body/div[1]/div[1]/div[2]/div/form/button[2]")
+                submit.send_keys(Keys.RETURN)
+        submit = WebDriverWait(selenium, 20).until(
+            EC.element_to_be_clickable((By.XPATH, '//*[@id="ccomplete-modal"]/div/div/div[2]/form/button')))
+        submit.click()
+        assert 'Start Judgment' in selenium.page_source
+        WebDriverWait(selenium, 20)
+        topic = Topic.objects.filter(title=scenario).first()
+        task = Task.objects.filter(topic_id=topic.id).first()
+        got = ''.join(sum([[y[0] for y in x.split('|') if y] for x in task.best_answers.split('--') if x], []))
+        expected = ''.join([x[0] for x in self.df[self.df.scenario == scenario].iloc[0].expected.split()])
+        assert got == expected
+
+

--- a/web/integration_test.py
+++ b/web/integration_test.py
@@ -1,40 +1,26 @@
 import re
-
 import pandas as pd
-from django.test.client import Client
-from django.test import TestCase
 from django.test import LiveServerTestCase
+from parameterized import parameterized
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
-from selenium import webdriver
+from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.wait import WebDriverWait
 from webdriver_manager.chrome import ChromeDriverManager
-from parameterized import parameterized, parameterized_class
-from selenium.webdriver.support import expected_conditions as EC
-from topic.models import Topic
-from document.models import Document
-
-from core.models import Task
-
-from user.models import User
 from core.models import Task
 from topic.models import Topic
 
 SCENARIOS_PATH = "https://docs.google.com/spreadsheets/d/1siwC0S1vgs_BB9lQC6z7J1smTDFA3P0oJMfcSy7DYME/export?gid=0&format=csv"
 
-class ATestCase(LiveServerTestCase):
-    # @parameterized.expand([(i,) for i in pd.read_csv(SCENARIOS_PATH).scenario.tolist()])
 
-    # @parameterized.expand([(i,) for i in range(1,2)])
-    # fixtures = ["test_ingest"]
-
+class SyntheticDataIntegrationTestCase(LiveServerTestCase):
 
     def setUp(self) -> None:
 
         with open('./fixtures/test_ingest.py') as f:
-          exec(f.read())
+            exec(f.read())
         self.df = pd.read_csv(
             SCENARIOS_PATH,
         )
@@ -43,7 +29,6 @@ class ATestCase(LiveServerTestCase):
     def test_stuff(self, scenario):
         print("test")
         selenium = webdriver.Chrome(ChromeDriverManager().install())
-        # Choose your url to visit
         selenium.get(self.live_server_url)
         user = selenium.find_element(By.ID, 'id_login')
         password = selenium.find_element(By.ID, 'id_password')
@@ -58,8 +43,6 @@ class ATestCase(LiveServerTestCase):
 
         select = Select(selenium.find_element(By.ID, 'slct'))
         select.select_by_visible_text(scenario)
-        # select.select_by_index(2)
-        topic_title = select.first_selected_option.text
         submit = selenium.find_element(By.XPATH, "//*[@id='container']/div/div/button")
         submit.send_keys(Keys.RETURN)
 
@@ -92,5 +75,3 @@ class ATestCase(LiveServerTestCase):
         got = ''.join(sum([[y[0] for y in x.split('|') if y] for x in task.best_answers.split('--') if x], []))
         expected = ''.join([x[0] for x in self.df[self.df.scenario == scenario].iloc[0].expected.split()])
         assert got == expected
-
-


### PR DESCRIPTION
This pull request is for discussion of Integration/System Testing with synthetic documents.

Right now we are writing scenarios in a [google sheets page](https://docs.google.com/spreadsheets/d/1siwC0S1vgs_BB9lQC6z7J1smTDFA3P0oJMfcSy7DYME/edit?usp=sharing).

Scenarios need to have a unique name, an input consisting of a series of synthetic documents (e.g. `A1`, `B12`, `F4`) and the expected output documents. The first character indicates preference. `A` documents will be preferred over `B` etc.

Documents are ingested using `web/fixtures/test_ingest.py`. Each scenario will be a topic. A test user is created and all topics are assigned as tasks to the user.

`fixtures/test_ingest.py` is called from `web/integration_test.py`'s setup. `integration_test.py` will dynamically run the scenarios listed in the google sheets file using selenium and a chrome driver to tun through all scenarios. Once judging is complete the task `best_answer` field is compared with the expected column in the google sheet.

We can write as many scenarios as we need and testing is repeatable. We just need to create the scenarios.

I'm not too familiar with the project's structure and conventions so if you need me to make any changes, I'm happy to oblige.

For a review, testers can try running the integration tests. On PyCharm you can just hit the green arrow next to the testcase class. In the meantime I'll cleanup the code and help write more scenarios.